### PR TITLE
fix typescript optional chain non null assertion

### DIFF
--- a/app/(platform)/(dashboard)/organization/[organizationId]/_components/info.tsx
+++ b/app/(platform)/(dashboard)/organization/[organizationId]/_components/info.tsx
@@ -26,7 +26,7 @@ export const Info = ({
       <div className="w-[60px] h-[60px] relative">
         <Image
           fill
-          src={organization?.imageUrl!}
+          src={organization!.imageUrl}
           alt="Organization"
           className="rounded-md object-cover"
         />

--- a/lib/subscription.ts
+++ b/lib/subscription.ts
@@ -29,7 +29,7 @@ export const checkSubscription = async () => {
 
   const isValid =
     orgSubscription.stripePriceId &&
-    orgSubscription.stripeCurrentPeriodEnd?.getTime()! + DAY_IN_MS > Date.now()
+    orgSubscription.stripeCurrentPeriodEnd!.getTime() + DAY_IN_MS > Date.now()
 
   return !!isValid;
 };


### PR DESCRIPTION
Optional chain expressions can return undefined by design, replace optional chain with non null assertion

https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/#examples